### PR TITLE
Removed modN, modL and modH

### DIFF
--- a/generator/src/Main.purs
+++ b/generator/src/Main.purs
@@ -71,13 +71,13 @@ keyShortcuts =
     , { n: "e", k: "e", m: [KeyNone, KeyMod] }
     , { n: "f", k: "f", m: [KeyNone, KeyMod] }
     , { n: "g", k: "g", m: [KeyNone, KeyMod] }
-    , { n: "h", k: "h", m: [KeyNone, KeyMod] }
+    , { n: "h", k: "h", m: [KeyNone] }
     , { n: "i", k: "i", m: [KeyNone, KeyMod] }
     , { n: "j", k: "j", m: [KeyNone, KeyMod] }
     , { n: "k", k: "k", m: [KeyNone, KeyMod] }
-    , { n: "l", k: "l", m: [KeyNone, KeyMod] }
+    , { n: "l", k: "l", m: [KeyNone] }
     , { n: "m", k: "m", m: [KeyNone] }
-    , { n: "n", k: "n", m: [KeyNone, KeyMod] }
+    , { n: "n", k: "n", m: [KeyNone] }
     , { n: "o", k: "o", m: [KeyNone, KeyMod] }
     , { n: "p", k: "p", m: [KeyNone, KeyMod] }
     , { n: "q", k: "q", m: [KeyNone] }

--- a/src/Data/Shortcut.purs
+++ b/src/Data/Shortcut.purs
@@ -33,7 +33,6 @@ module Data.Shortcut
   , g
   , modG
   , h
-  , modH
   , i
   , modI
   , j
@@ -41,10 +40,8 @@ module Data.Shortcut
   , k
   , modK
   , l
-  , modL
   , m
   , n
-  , modN
   , o
   , modO
   , p
@@ -324,9 +321,6 @@ modG = KeyShortcut "g" KeyMod
 h :: Shortcut
 h = KeyShortcut "h" KeyNone
 
-modH :: Shortcut
-modH = KeyShortcut "h" KeyMod
-
 i :: Shortcut
 i = KeyShortcut "i" KeyNone
 
@@ -348,17 +342,11 @@ modK = KeyShortcut "k" KeyMod
 l :: Shortcut
 l = KeyShortcut "l" KeyNone
 
-modL :: Shortcut
-modL = KeyShortcut "l" KeyMod
-
 m :: Shortcut
 m = KeyShortcut "m" KeyNone
 
 n :: Shortcut
 n = KeyShortcut "n" KeyNone
-
-modN :: Shortcut
-modN = KeyShortcut "n" KeyMod
 
 o :: Shortcut
 o = KeyShortcut "o" KeyNone


### PR DESCRIPTION
`modN` would unpreventably open a new browser window 
`modL` would unpreventably shift focus to the location input
`modN` would unpreventably hide application windows on some Apple platforms